### PR TITLE
Consolidate haphazard drawing

### DIFF
--- a/src/gfx/factory.cpp
+++ b/src/gfx/factory.cpp
@@ -1,0 +1,30 @@
+#include <gfx/factory.hpp>
+#include <maths/maths.hpp>
+
+using namespace misc::maths;
+
+void misc::transform(sf::Transformable& out, sf::Vector2f bounds, transform_t const& tr) {
+	out.setOrigin(tr.n_pivot * bounds);
+	out.setPosition(screen(tr.position));
+	out.setRotation(tr.orientation.deg());
+	out.setScale(tr.scale);
+}
+
+template <>
+void misc::setup_shape(sf::CircleShape& shape, shape_params_t<sf::CircleShape> const& params, transform_t const& tr) {
+	shape.setFillColor(params.fill);
+	shape.setOutlineColor(params.outline.colour);
+	shape.setOutlineThickness(params.outline.size);
+	shape.setPointCount(params.points);
+	shape.setRadius(params.radius);
+	transform(shape, {params.radius * 2, params.radius * 2}, tr);
+}
+
+template <>
+void misc::setup_shape(sf::RectangleShape& shape, shape_params_t<sf::RectangleShape> const& params, transform_t const& tr) {
+	shape.setFillColor(params.fill);
+	shape.setOutlineColor(params.outline.colour);
+	shape.setOutlineThickness(params.outline.size);
+	shape.setSize(params.size);
+	transform(shape, params.size, tr);
+}

--- a/src/gfx/factory.hpp
+++ b/src/gfx/factory.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <gfx/orient.hpp>
+#include <typelist.hpp>
+
+namespace misc {
+// world space: centred origin, +x right, +y up
+struct transform_t {
+	sf::Vector2f position{};
+	orient_t orientation;
+	sf::Vector2f scale = {1.0f, 1.0f};
+	maths::npt_t n_pivot = {0.5f, 0.5f};
+};
+
+struct common_params_t {
+	sf::Color fill = sf::Color::White;
+	struct {
+		sf::Color colour = sf::Color::Transparent;
+		f32 size = 0.0f;
+	} outline;
+};
+
+using valid_shapes_t = typelist<sf::RectangleShape, sf::CircleShape>;
+template <typename T>
+constexpr bool is_valid_shape_v = contains_type<valid_shapes_t, T>();
+
+template <typename T>
+struct shape_params_t;
+
+template <>
+struct shape_params_t<sf::RectangleShape> : common_params_t {
+	sf::Vector2f size = {20.0f, 20.0f};
+};
+
+template <>
+struct shape_params_t<sf::CircleShape> : common_params_t {
+	u32 points = 64;
+	f32 radius = 10.0f;
+};
+
+// screen space: +x right, +y down
+inline sf::Vector2f screen(sf::Vector2f world, sf::Vector2f offset = {}) noexcept { return offset + sf::Vector2f{world.x, -world.y}; }
+
+void transform(sf::Transformable& out, sf::Vector2f bounds, transform_t const& tr = {});
+
+template <typename T>
+void setup_shape(T& shape, shape_params_t<T> const& params, transform_t const& tr = {});
+
+// impl
+
+template <>
+void setup_shape(sf::CircleShape& shape, shape_params_t<sf::CircleShape> const& params, transform_t const& tr);
+template <>
+void setup_shape(sf::RectangleShape& shape, shape_params_t<sf::RectangleShape> const& params, transform_t const& tr);
+} // namespace misc

--- a/src/gfx/follow_eye.cpp
+++ b/src/gfx/follow_eye.cpp
@@ -1,44 +1,24 @@
 #include <context.hpp>
 #include <gfx/follow_eye.hpp>
+#include <gfx/shape.hpp>
 #include <maths/maths.hpp>
 
 namespace misc {
-namespace {
-struct circle_params_t {
-	sf::Vector2f position{};
-	sf::Color fill = sf::Color::White;
-	sf::Color outline = sf::Color::Transparent;
-	f32 radius = 25.0f;
-	u32 points = 64;
-};
-
-void draw_circle(drawer_t& drawer, circle_params_t const& params) {
-	sf::CircleShape circle;
-	circle.setFillColor(params.fill);
-	circle.setOutlineColor(params.outline);
-	circle.setPointCount(params.points);
-	circle.setRadius(params.radius);
-	circle.setOrigin(params.radius, params.radius);
-	circle.setPosition(params.position.x, -params.position.y);
-	drawer.draw(circle);
-}
-} // namespace
-
-sf::Vector2f follow_eye_t::update(sf::Vector2f target) noexcept { return (dir = maths::norm(target - pos)); }
+sf::Vector2f follow_eye_t::update(sf::Vector2f target) noexcept { return (dir = maths::normalize(target - pos)); }
 void follow_eye_t::draw(drawer_t& drawer, bool blink) {
-	circle_params_t params;
-	params.radius = 40.0f * scale;
-	params.outline = sf::Color(0x221100ff);
-	params.position = pos;
-	draw_circle(drawer, params);
+	shape_t<sf::CircleShape> circle(drawer);
+	circle.radius = 40.0f * scale;
+	circle.outline = {sf::Color(0x221100ff), 2.0f};
+	circle.position = pos;
+	circle.draw();
 	if (!blink) {
-		auto const radius = params.radius * 0.25f;
-		auto const offset = dir * (params.radius - radius) * 0.80f; // 20% padding
-		params.radius *= 0.25f;
-		params.outline = sf::Color::Transparent;
-		params.fill = sf::Color::Black;
-		params.position += offset;
-		draw_circle(drawer, params);
+		auto const radius = circle.radius * 0.25f;
+		auto const offset = dir * (circle.radius - radius) * 0.80f; // 20% padding
+		circle.radius = radius;
+		circle.fill = sf::Color::Black;
+		circle.outline.size = 0.0f;
+		circle.position += offset;
+		circle.draw();
 	}
 }
 } // namespace misc

--- a/src/gfx/orient.hpp
+++ b/src/gfx/orient.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <maths/maths.hpp>
+
+namespace misc {
+// rotation: right-handed i x j (+radians counter-clockwise), identity facing up (+y)
+struct orient_t {
+	inline static maths::dir2_t const identity = {0.0f, 1.0f};
+
+	maths::dir2_t dir_n = identity;
+
+	orient_t() = default;
+	orient_t(sf::Vector2f dir) noexcept : dir_n(maths::normalize(dir)) {}
+	orient_t(maths::rad_t rad) noexcept : dir_n(maths::dir(rad)) {}
+
+	maths::rad_t rad() const noexcept { return maths::rad(dir_n); }
+	f32 deg() const noexcept { return maths::deg(rad()); }
+};
+} // namespace misc

--- a/src/gfx/shape.hpp
+++ b/src/gfx/shape.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <context.hpp>
+#include <gfx/factory.hpp>
+
+namespace misc {
+template <typename T>
+	requires is_valid_shape_v<T>
+class shape_t : public shape_params_t<T>, public transform_t {
+  public:
+	using type = T;
+
+	shape_t(drawer_t& drawer) : m_drawer(drawer) {}
+
+	T const& shape() const noexcept { return m_t; }
+	T& shape() noexcept { return m_t; }
+
+	void draw() {
+		setup_shape(m_t, *this, *this);
+		m_drawer.draw(m_t);
+	}
+
+  private:
+	drawer_t& m_drawer;
+	T m_t;
+};
+} // namespace misc

--- a/src/maths/maths.hpp
+++ b/src/maths/maths.hpp
@@ -11,23 +11,31 @@ using rad_t = f32;
 template <bool V, typename...>
 constexpr bool value_v = V;
 
+// normalized direction (magnitude = 1)
+using dir2_t = sf::Vector2f;
+// point in normalized coords ([0-1], [0-1])
+using npt_t = sf::Vector2f;
+
 constexpr f32 pi = 3.1415;
-sf::Vector2f const n_up = {0.0f, 1.0f};
-sf::Vector2f const n_down = {0.0f, -1.0f};
-sf::Vector2f const n_left = {-1.0f, 0.0f};
-sf::Vector2f const n_right = {1.0f, 0.0f};
+dir2_t const up_n = {0.0f, 1.0f};
+dir2_t const down_n = {0.0f, -1.0f};
+dir2_t const left_n = {-1.0f, 0.0f};
+dir2_t const right_n = {1.0f, 0.0f};
 
 constexpr rad_t rad(f32 degrees) noexcept;
 constexpr f32 deg(rad_t rad) noexcept;
 
+template <typename T>
+sf::Vector2<T> operator*(sf::Vector2<T> lhs, sf::Vector2<T> rhs) noexcept;
+
 f32 sqr_mag(sf::Vector2f vec) noexcept;
 f32 mag(sf::Vector2f vec) noexcept;
 f32 mag_or(sf::Vector2f vec, f32 fallback) noexcept;
-sf::Vector2f norm(sf::Vector2f vec) noexcept;
-sf::Vector2f safe_norm(sf::Vector2f vec) noexcept;
+sf::Vector2f normalize(sf::Vector2f vec) noexcept;
+dir2_t normalize_safe(sf::Vector2f vec) noexcept;
 
-sf::Vector2f dir(rad_t rad) noexcept;
-rad_t rad(sf::Vector2f n_dir) noexcept;
+dir2_t dir(rad_t rad) noexcept;
+rad_t rad(dir2_t dir_n) noexcept;
 
 template <typename Ret, typename In>
 Ret cast(sf::Vector2<In> in) noexcept;
@@ -39,6 +47,12 @@ T random_range(T lo, T hi) noexcept;
 
 constexpr rad_t rad(f32 degrees) noexcept { return degrees * pi / 180.0f; }
 constexpr f32 deg(rad_t radians) noexcept { return 180.0f * radians / pi; }
+
+template <typename T>
+sf::Vector2<T> operator*(sf::Vector2<T> lhs, sf::Vector2<T> rhs) noexcept {
+	return {lhs.x * rhs.x, lhs.y * rhs.y};
+}
+
 inline f32 sqr_mag(sf::Vector2f vec) noexcept { return vec.x * vec.x + vec.y * vec.y; }
 inline f32 mag(sf::Vector2f vec) noexcept { return std::sqrt(sqr_mag(vec)); }
 
@@ -47,21 +61,21 @@ inline f32 mag_or(sf::Vector2f vec, f32 fallback) noexcept {
 	return ret == 0.0f ? fallback : ret;
 }
 
-inline sf::Vector2f norm(sf::Vector2f vec) noexcept {
+inline sf::Vector2f normalize(sf::Vector2f vec) noexcept {
 	auto const m = mag(vec);
 	return {vec.x / m, vec.y / m};
 }
 
-inline sf::Vector2f safe_norm(sf::Vector2f vec) noexcept {
-	auto const m = mag_or(vec, 1.0f);
-	return {vec.x / m, vec.y / m};
+inline dir2_t normalize_safe(sf::Vector2f vec) noexcept {
+	if (sqr_mag(vec) == 0.0f) { return up_n; }
+	return normalize(vec);
 }
 
-inline sf::Vector2f dir(rad_t rad) noexcept { return {std::sin(rad), std::cos(rad)}; }
-inline rad_t rad(sf::Vector2f n_dir) noexcept {
-	if (n_dir.y == 0.0f) { return rad(n_dir.x == 1.0f ? -90.0f : 90.0f); }
-	auto const atan = std::atan(n_dir.x / n_dir.y);
-	return n_dir.y > 0.0f ? atan : atan + rad(180.0f);
+inline dir2_t dir(rad_t rad) noexcept { return {std::sin(rad), std::cos(rad)}; }
+inline rad_t rad(dir2_t dir_n) noexcept {
+	if (dir_n.y == 0.0f) { return rad(dir_n.x == 1.0f ? -90.0f : 90.0f); }
+	auto const atan = std::atan(dir_n.x / dir_n.y);
+	return dir_n.y > 0.0f ? atan : atan + rad(180.0f);
 }
 
 template <typename Ret, typename In>

--- a/src/typelist.hpp
+++ b/src/typelist.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <type_traits>
+
+namespace misc {
+template <typename... T>
+struct typelist;
+
+template <typename T, typename... Ts>
+struct typelist<T, Ts...> {
+	using head_t = T;
+};
+
+template <typename Typelist>
+struct typelist_pop;
+template <typename Typelist>
+using typelist_pop_t = typename typelist_pop<Typelist>::type;
+
+template <typename T, typename... Ts>
+struct typelist_pop<typelist<T, Ts...>> {
+	using type = typelist<Ts...>;
+};
+
+template <typename Typelist>
+constexpr bool is_empty_list_v = std::is_same_v<Typelist, typelist<>>;
+
+template <typename T, typename Typelist>
+constexpr bool is_head_v = std::is_same_v<T, typename Typelist::head_t>;
+
+template <typename Typelist, typename T>
+constexpr bool contains_type() noexcept {
+	if constexpr (is_empty_list_v<Typelist>) {
+		return false;
+	} else if constexpr (is_head_v<T, Typelist>) {
+		return true;
+	} else {
+		return contains_type<typelist_pop_t<Typelist>, T>();
+	}
+}
+} // namespace misc

--- a/src/world_clock/gui.cpp
+++ b/src/world_clock/gui.cpp
@@ -3,6 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <context.hpp>
 #include <gfx/follow_eye.hpp>
+#include <gfx/shape.hpp>
 #include <world_clock/gui.hpp>
 
 namespace misc {
@@ -11,73 +12,26 @@ using in_t = world_clock_drawer_t::in_t;
 
 constexpr f32 max_rotation = 360.0f;
 
-f32 rotation(hour_t hour) noexcept { return max_rotation * hour / total_hours; }
+maths::rad_t rotation(hour_t hour) noexcept { return maths::rad(max_rotation * hour / total_hours); }
 
-sf::Vector2f to_screen(sf::Vector2f world) noexcept { return {world.x, -world.y}; }
-
-void init(sf::Transformable& out, sf::Vector2f origin, sf::Vector2f position = {}, f32 rotation = {}) {
-	out.setOrigin(origin);
-	out.setPosition(to_screen(position));
-	out.setRotation(rotation);
+void init_hand(shape_t<sf::RectangleShape>& out, u32 colour, world_hour_t hour, in_t const& in) {
+	out.fill = sf::Color(colour);
+	out.size = sf::Vector2f(in.hand_height * 0.08f, in.hand_height) * in.scale;
+	out.position = in.centre;
+	out.orientation = rotation(hour.hour());
+	out.n_pivot = in.hand_pivot;
 }
 
-void init(sf::Sprite& out, sf::Texture const& texture, sf::Vector2f scale, sf::Color colour) {
-	out.setTexture(texture);
-	out.setScale(scale);
-	out.setColor(colour);
-}
-
-void init(sf::RectangleShape& out_hand, u32 colour, world_hour_t hour, in_t const& in) {
-	auto const size = sf::Vector2f(in.hand_height * 0.08f, in.hand_height) * in.scale;
-	sf::Vector2f const origin = {size.x * in.hand_pivot.x, size.y * in.hand_pivot.y};
-	out_hand.setFillColor(sf::Color(colour));
-	out_hand.setSize(size);
-	init(out_hand, origin, in.centre, rotation(hour.hour()));
-}
-
-void init(sf::Sprite& out_hand, u32 colour, world_hour_t hour, in_t const& in) {
-	auto const size = in.hand_tex->getSize();
-	sf::Vector2f const origin = {f32(size.x) * in.hand_pivot.x, f32(size.y) * in.hand_pivot.y};
-	sf::Vector2f const scale = {in.hand_height / f32(size.y), in.hand_height / f32(size.y)};
-	init(out_hand, origin, in.centre, rotation(hour.hour()));
-	init(out_hand, *in.hand_tex, scale * in.scale, sf::Color(colour));
-}
-
-void init(sf::CircleShape& out_face, f32 radius, in_t const& in) {
-	out_face.setFillColor(in.face_tint);
-	out_face.setRadius(radius);
-	out_face.setPointCount(50);
-	init(out_face, {radius, radius}, in.centre);
-}
-
-void init(sf::Sprite& out_face, in_t const& in) {
-	auto const origin = in.face_tex->getSize() / 2U;
-	f32 const radius = in.hand_height * (1.0f + in.face_pad);
-	sf::Vector2f const scale = {radius / f32(origin.x), radius / f32(origin.y)};
-	init(out_face, {f32(origin.x), f32(origin.y)}, in.centre);
-	init(out_face, *in.face_tex, scale * in.scale, sf::Color::White);
-}
-
-void init(sf::CircleShape& out_marker, world_hour_t hour, f32 clock_radius, in_t const& in) {
-	f32 const radians = rotation(hour.hour()) * 3.14f / 180.0f;
-	sf::Vector2f const direction = {std::sin(radians), std::cos(radians)};
-	sf::Vector2f const offset = direction * clock_radius * 0.9f;
-	f32 const marker_radius = in.marker_radius * in.scale;
-	out_marker.setFillColor(in.marker_tint);
-	out_marker.setRadius(marker_radius);
-	init(out_marker, {marker_radius, marker_radius}, in.centre + offset, rotation(hour.hour()));
+void init_marker(shape_t<sf::CircleShape>& out, world_hour_t hour, f32 clock_radius, in_t const& in) {
+	sf::Vector2f const offset = maths::dir(rotation(hour.hour())) * clock_radius * 0.9f; // 10% padding
+	out.fill = in.marker_tint;
+	out.radius = in.marker_radius * in.scale;
+	out.position = in.centre + offset;
 }
 
 struct facade_t {
 	drawer_t& drawer;
 	in_t const& in;
-
-	template <typename T, typename... Args>
-	void draw(Args&&... args) const {
-		T t;
-		init(t, std::forward<Args>(args)..., in);
-		drawer.draw(t);
-	}
 
 	void draw_eyes(sf::Vector2f target, bool blink) const {
 		follow_eye_t left;
@@ -92,25 +46,25 @@ struct facade_t {
 	}
 
 	void draw_clock() const {
-		if (in.face_tex) {
-			draw<sf::Sprite>();
-		} else {
-			f32 const radius = in.hand_height * (1.0f + in.face_pad);
-			draw<sf::CircleShape>(radius);
-			static constexpr int count = 8;
-			for (int i = 0; i < count; ++i) {
-				hour_t const hour = total_hours * f32(i) / f32(count);
-				draw<sf::CircleShape>(world_hour_t(hour), radius);
-			}
+		f32 const radius = in.hand_height * (1.0f + in.face_pad);
+		shape_t<sf::CircleShape> face(drawer);
+		face.fill = in.face_tint;
+		face.radius = radius;
+		face.position = in.centre;
+		face.draw();
+		static constexpr int count = 8;
+		for (int i = 0; i < count; ++i) {
+			hour_t const hour = total_hours * f32(i) / f32(count);
+			shape_t<sf::CircleShape> marker(drawer);
+			init_marker(marker, world_hour_t(hour), radius, in);
+			marker.draw();
 		}
 	}
 
 	void draw_hand(world_clock_t::entry_t const& entry) const {
-		if (in.hand_tex) {
-			draw<sf::Sprite>(entry.colour, entry.hour);
-		} else {
-			draw<sf::RectangleShape>(entry.colour, entry.hour);
-		}
+		shape_t<sf::RectangleShape> hand(drawer);
+		init_hand(hand, entry.colour, entry.hour, in);
+		hand.draw();
 	}
 };
 } // namespace

--- a/src/world_clock/gui.hpp
+++ b/src/world_clock/gui.hpp
@@ -17,8 +17,6 @@ struct world_clock_drawer_t {
 		sf::Vector2f mouse_pos{};
 		sf::Color face_tint = sf::Color(0xccccbbff);
 		sf::Color marker_tint = sf::Color(0x555555ff);
-		sf::Texture const* face_tex{};
-		sf::Texture const* hand_tex{};
 		f32 hand_height = 250.0f;
 		f32 marker_radius = 10.0f;
 		f32 face_pad = 0.2f;


### PR DESCRIPTION
- Add orient, transform, factory, shape<T>, etc.
- Centralize world space basis and conventions in orient and transform.
- Use one requires clause (to demonstrate its usage).
- Remove texture support.
