### PR TITLE
enable adding timezones through pini

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <filesystem>
 #include <iostream>
 #include <set>
 #include <context.hpp>
@@ -8,6 +9,7 @@
 #include <pini/pini.hpp>
 #include <world_clock/gui.hpp>
 #include <world_clock/io.hpp>
+#include "world_clock/world_clock.hpp"
 
 using namespace misc;
 
@@ -111,13 +113,21 @@ class clock_ticker_t {
 };
 } // namespace
 
+bool load_timezones(std::filesystem::path const& filename, world_clock_t& clock) {
+	pn::pini timezones;
+	if (!timezones.load_file(filename)) { return false; }
+
+	for (auto& pair : timezones) {
+		std::cout << pair.first << " " << pair.second << '\n';
+		clock.add(pair.first, 0xff8800ff, timezones.get_double(pair.first));
+	}
+	return true;
+}
 int main() {
 	misc::context_t ctx("World Clock");
 	ctx.setVerticalSyncEnabled(true);
 	world_clock_t clock;
-	clock.add("PDT", 0xff8800ff, -7.0f);
-	clock.add("IST", 0x44ddffff, 5.5f);
-	clock.add("CET", 0x11ee44ff, 2.0f);
+	load_timezones("src/timezones.pini", clock);
 	std::cout << clock << '\n';
 	input_t input;
 	delta_time_t dt;

--- a/src/timezones.pini
+++ b/src/timezones.pini
@@ -1,0 +1,8 @@
+GMT=0
+ECT=1
+EET=2
+MET=3
+IST=5.3
+PST=-8
+EST=-5
+


### PR DESCRIPTION
Added a testing `.pini` file with several examples.
The time zones get checked and added every time the program is ran.
Main issue is that the colors aren't random but that will be fixed in later commits.